### PR TITLE
Update Dockerfile commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -286,12 +286,13 @@ You can create the directory from within the boot2docker-vm with the following c
     ![Alt text](/screenshots/dockerfile_windows_explorer.png?raw=true "Windows Explorer Dockerfile")
 
 
-3.  Edit the newly created `Dockerfile` and add the following two lines:
+3.  Edit the newly created `Dockerfile` and add the following four lines:
 
     ````
     FROM centos/wildfly
-
     ADD javaee6angularjs.war /opt/wildfly/standalone/deployments/
+    USER root
+    RUN chown wildfly:wildfly /opt/wildfly/standalone/deployments/javaee6angularjs.war
     ````
 
     > The trailing "/" does matter


### PR DESCRIPTION
I had permission issues with the centos image running on MacOS/Boot2Docker 1.4.1. It causes the javaee6angularjs.war to be copied using root ownership and 740 permission. That caused WildFly to throw a FileNotFoundException. 

The proposed changes fix that issue by placing the file under wildfly ownership. There's a docker issue opened about that issue: https://github.com/docker/docker/issues/6119
